### PR TITLE
Fix: Show right helicopter in dialog

### DIFF
--- a/Client/Classes/Dialogs/ProfessionDialog.sqx
+++ b/Client/Classes/Dialogs/ProfessionDialog.sqx
@@ -197,11 +197,10 @@ namespace Intrusion.Client
 				"_weaponNames" as String,
 				"_squadsInBrigade" as String
 			];
-			private _model = "";
 			private _vehicleNames = []; 
-			private _ctrlVehicleModel = (findDisplay 2999) displayCtrl 2230;
+			private _ctrlVehiclePicture = (findDisplay 2999) displayCtrl 2231;
 			private _ctrlDescription = (findDisplay 2999) displayCtrl 2215;
-			//_profession = call _self.GetSelectedProfessionTypeFromCombo;
+			
 			_profession = [call _self.GetSelectedProfessionTypeFromCombo] call _mProfessionConfig.GetProfession;
 			_vehicles = [side player, _profession.Type] call _mVehicleClassNamesConfig.GetProVehiclesClassNameInfo;
 
@@ -227,12 +226,12 @@ namespace Intrusion.Client
  			if (!isNull _vehicles) then {
 
  				if (count _vehicles.ClassNames > 0) then {
-					_className = _vehicles.ClassNames select ((count _vehicles.ClassNames) - 1);
-					_model = (getText(configFile >> "cfgVehicles" >> _className >> "model"));
-					_ctrlVehicleModel ctrlSetModel _model;
-					_ctrlVehicleModel ctrlShow true;
+					_className = _vehicles.ClassNames select 0;
+					_ctrlVehiclePicture ctrlSetText (getText(configFile >> "cfgVehicles" >> _className >> "editorPreview"));
+					_ctrlVehiclePicture ctrlShow true;
 					
 					_vehicleNames = (getText(configFile >> "cfgVehicles" >> _className >> "displayName"));
+					
 				};
 
  				if (count _vehicles.ClassNames > 1) then {
@@ -246,9 +245,8 @@ namespace Intrusion.Client
 				};
 				
 			} else {
-				/* Set a compass as vehicle picture and hide it */
-				_ctrlVehicleModel ctrlSetModel "\a3\Ui_f\objects\Compass.p3d";
-				_ctrlVehicleModel ctrlShow false;
+				_ctrlVehiclePicture ctrlSetText "";
+				_ctrlVehiclePicture ctrlShow false;
 			};
 
 

--- a/Dialogs/ProfessionDialog.hpp
+++ b/Dialogs/ProfessionDialog.hpp
@@ -2,26 +2,17 @@ class IntProfessionDialog
 {
     idd = 2999;
     movingenable = false;
-    
-    class Objects 
-    {
-		class RscModel_2230 : RscObject
-		{
-			idc = 2230;
-			scale = 0.5;
-			z = 8.5;
-			//model = "\A3\armor_f_beta\APC_Tracked_01\APC_Tracked_01_rcws_F.p3d";
-			x = 13 * GUI_GRID_W + GUI_GRID_X;
-			y = 6 * GUI_GRID_H + GUI_GRID_Y;
-			w = 27.5 * GUI_GRID_W;
-			h = 10 * GUI_GRID_H;
-		};
-		
-	};
-
 
 	class Controls
     {
+	    class RscModel_2231 : RscPicture
+			{
+				idc = 2231;
+				x = 0.5 * GUI_GRID_W + GUI_GRID_X;
+				y = 2.5 * GUI_GRID_H + GUI_GRID_Y;
+				w = 26.5 * GUI_GRID_W;
+				h = 9.5 * GUI_GRID_H;
+			};
 		
 		class IntProfessionDialog_CancelButton : IntBaseDialog_CancelButton {
 			x = 27.5 * GUI_GRID_W + GUI_GRID_X;
@@ -33,9 +24,9 @@ class IntProfessionDialog
 
 		class IntProfessionDialog_OkButton : IntBaseDialog_OkButton {
 			idc = 2210;
-			x = 36 * GUI_GRID_W + GUI_GRID_X;
+			x = 34.5 * GUI_GRID_W + GUI_GRID_X;
 			y = 22.5 * GUI_GRID_H + GUI_GRID_Y;
-			w = 3.5 * GUI_GRID_W;
+			w = 5 * GUI_GRID_W;
 			h = 1.5 * GUI_GRID_H;
 			text = "Select";
 			action = "call Intrusion_Client_ProfessionDialog_OnOkButtonPressed;";
@@ -50,9 +41,9 @@ class IntProfessionDialog
 		{
 			idc = 2200;
 			x = 27.5 * GUI_GRID_W + GUI_GRID_X;
-			y = 1 * GUI_GRID_H + GUI_GRID_Y;
+			y = 2.5 * GUI_GRID_H + GUI_GRID_Y;
 			w = 12 * GUI_GRID_W;
-			h = 20.5 * GUI_GRID_H;
+			h = 19 * GUI_GRID_H;
 			
 			onLBSelChanged = "call Intrusion_Client_ProfessionDialog_OnListSelectChanged;";
 		};

--- a/Dialogs/ProfessionDialog.hpp
+++ b/Dialogs/ProfessionDialog.hpp
@@ -5,7 +5,7 @@ class IntProfessionDialog
 
 	class Controls
     {
-	    class RscModel_2231 : RscPicture
+	    class IntProfessionDialog_VehiclePicture : RscPicture
 			{
 				idc = 2231;
 				x = 0.5 * GUI_GRID_W + GUI_GRID_X;


### PR DESCRIPTION
I changed from showing the model to showing a editor preview image instead. This because that the model can't be rendered with another texture and the base model was a civil copter .