### PR TITLE
FIX: Incapacitated units wakes up from death

### DIFF
--- a/Engima/ReviveFix/Code/EventHandlers.sqf
+++ b/Engima/ReviveFix/Code/EventHandlers.sqf
@@ -39,7 +39,7 @@ if (ENGIMA_REVIVEFIX_alwaysUnconscious) then
 
 		if (ENGIMA_RESPAWNFIX_playerIsIncapacitated) then
 		{
-			_damage = 0;
+			_damage = 0.99;
 		}
 		else
 		{


### PR DESCRIPTION
Om en spelare är i en bil som sprängs, så kastas den spelaren ut och får 0.99 i damage.
Problemet som varit är att eventhandlern "HandleDamage" körs flera gånger i följd, och då sätts spelarens skada till 0 vilket får till följd att spelaren vaknar upp ur sin "dvala".

Denna pr gör så att spelaren inte vaknar upp automatiskt efter en bilexplosion.